### PR TITLE
Feat/answer similarity

### DIFF
--- a/flow_eval/eval_data_types.py
+++ b/flow_eval/eval_data_types.py
@@ -21,7 +21,7 @@ class EvalOutput(BaseModel):
     """Output model for evaluation results supporting multiple score types."""
 
     feedback: str | None = Field(None, description="Optional feedback from the evaluation")
-    score: int | bool | str | None = Field(
+    score: int | float | bool | str | None = Field(
         None, description="Evaluation result (numeric, boolean, or categorical)"
     )
 

--- a/flow_eval/evaluators/answer_similarity.py
+++ b/flow_eval/evaluators/answer_similarity.py
@@ -34,9 +34,16 @@ class AnswerSimilarityEvaluator(BaseEvaluator):
         self.model_type = model_type
         self.eval_name = eval_name
         self.similarity_fn_name = getattr(SimilarityFunction, similarity_fn_name.upper())
-        self.model = SentenceTransformer(
-            self.model_name, similarity_fn_name=self.similarity_fn_name
-        )
+        self._model = None
+
+    @property
+    def model(self) -> SentenceTransformer:
+        """Lazy initialization of the model."""
+        if self._model is None:
+            self._model = SentenceTransformer(
+                self.model_name, similarity_fn_name=self.similarity_fn_name
+            )
+        return self._model
 
     def _compute_similarity(self, text1: str, text2: str) -> float:
         """Compute similarity between two texts using sentence-transformers similarity function."""
@@ -84,7 +91,7 @@ class AnswerSimilarityEvaluator(BaseEvaluator):
             eval_outputs,
             {
                 "model_id": self.model_name,
-                "model_type": "sentence-transformer",
+                "model_type": self.model_type,
                 "similarity_fn_name": self.similarity_fn_name,
             },
             self.eval_name,

--- a/flow_eval/evaluators/answer_similarity.py
+++ b/flow_eval/evaluators/answer_similarity.py
@@ -45,10 +45,29 @@ class AnswerSimilarityEvaluator(BaseEvaluator):
             )
         return self._model
 
+    def _check_text_lengths(self, text1: str, text2: str) -> None:
+        """Check if texts length exceeds model's maximum sequence length."""
+        max_length = self.model.get_max_seq_length()
+
+        for text, source in [(text1, "output"), (text2, "expected_output")]:
+            # Use encode to get the token count with special tokens
+            tokens = self.model.tokenizer.encode(text)
+            tokenized_length = len(tokens)
+
+            if tokenized_length > max_length:
+                logger.warning(
+                    f"{source} length ({tokenized_length} tokens) exceeds model's "
+                    f"maximum sequence length ({max_length} tokens). Text will be truncated. "
+                    "Consider using a model with longer sequence length for better results. "
+                    "See available models at: https://www.sbert.net/docs/pretrained_models.html"
+                )
+
     def _compute_similarity(self, text1: str, text2: str) -> float:
         """Compute similarity between two texts using sentence-transformers similarity function."""
-        # Use sentence-transformers built-in similarity function
-        # (will handle normalization internally if needed for the chosen similarity function)
+        # Check text lengths
+        self._check_text_lengths(text1, text2)
+
+        # Convert texts to embeddings
         emb1 = self.model.encode(text1)
         emb2 = self.model.encode(text2)
 


### PR DESCRIPTION
Main changes: 

Eval Output: 
- added float as data type 

Similarity metrics: 
- Opted to use the built-in similarity metrics from sentenceTransformer 
- The similarity metric that is used is stored in the SentenceTransformer instance under [SentenceTransformer.similarity_fn_name]. Valid options are:

- SimilarityFunction.COSINE (a.k.a “cosine”): Cosine Similarity (default)
- SimilarityFunction.DOT_PRODUCT (a.k.a “dot”): Dot Product
- SimilarityFunction.EUCLIDEAN (a.k.a “euclidean”): Negative Euclidean Distance
- SimilarityFunction.MANHATTAN (a.k.a. “manhattan”): Negative Manhattan Distance
--> no normalization separately needed, these functions take care of it when necessary  

Intended use: 

```
from flow_eval.evaluators import AnswerSimilarityEvaluator
from flow_eval.eval_data_types import EvalInput 

# 1. Create evaluator
evaluator = AnswerSimilarityEvaluator(
    model_name="all-MiniLM-L6-v2",  # any sentence-transformers model
    similarity_fn_name="cosine",  # optional: "cosine", "euclidean", or "dot", "manhattan"
)

# 2. Create input
# - Must have exactly one value in output
# - Must have exactly one value in expected_output
eval_input = EvalInput(
    # but there can be, they are ignored
    output={"response": "The cat sat on the mat"},
    expected_output={"reference": "A cat is sitting on a mat"}
)

# 3. Evaluate
result = evaluator.evaluate(eval_input, save_results=True)
print(f"Similarity score: {result.score}")
```
